### PR TITLE
cmd,eth/ethconfig: default bera-geth startup to Berachain mainnet

### DIFF
--- a/cmd/bera-geth/chaincmd.go
+++ b/cmd/bera-geth/chaincmd.go
@@ -340,16 +340,20 @@ func dumpGenesis(ctx *cli.Context) error {
 
 	db, err := stack.OpenDatabaseWithOptions("chaindata", node.DatabaseOptions{ReadOnly: true})
 	if err != nil {
-		return err
+		genesis = utils.MakeGenesis(ctx)
+	} else {
+		defer db.Close()
+		if rawdb.ReadCanonicalHash(db, 0) == (common.Hash{}) {
+			genesis = utils.MakeGenesis(ctx)
+		} else {
+			genesis, err = core.ReadGenesis(db)
+			if err != nil {
+				utils.Fatalf("failed to read genesis: %s", err)
+			}
+		}
 	}
-	defer db.Close()
 
-	genesis, err = core.ReadGenesis(db)
-	if err != nil {
-		utils.Fatalf("failed to read genesis: %s", err)
-	}
-
-	if err := json.NewEncoder(os.Stdout).Encode(*genesis); err != nil {
+	if err := json.NewEncoder(os.Stdout).Encode(genesis); err != nil {
 		utils.Fatalf("could not encode stored genesis: %s", err)
 	}
 

--- a/cmd/bera-geth/chaincmd.go
+++ b/cmd/bera-geth/chaincmd.go
@@ -338,11 +338,15 @@ func dumpGenesis(ctx *cli.Context) error {
 	// dump whatever already exists in the datadir
 	stack, _ := makeConfigNode(ctx)
 
-	db, err := stack.OpenDatabaseWithOptions("chaindata", node.DatabaseOptions{ReadOnly: true})
-	if err != nil {
+	if rawdb.PreexistingDatabase(stack.ResolvePath("chaindata")) == "" {
 		genesis = utils.MakeGenesis(ctx)
 	} else {
+		db, err := stack.OpenDatabaseWithOptions("chaindata", node.DatabaseOptions{ReadOnly: true})
+		if err != nil {
+			return err
+		}
 		defer db.Close()
+
 		if rawdb.ReadCanonicalHash(db, 0) == (common.Hash{}) {
 			genesis = utils.MakeGenesis(ctx)
 		} else {

--- a/cmd/bera-geth/main.go
+++ b/cmd/bera-geth/main.go
@@ -311,6 +311,11 @@ func prepare(ctx *cli.Context) {
 
 	case ctx.IsSet(utils.BerachainFlag.Name):
 		log.Info("Starting bera-geth on Berachain mainnet...")
+
+	default:
+		if !ctx.IsSet(utils.DeveloperFlag.Name) {
+			log.Info("Starting bera-geth on Berachain mainnet...")
+		}
 	}
 
 	// If we're a full node on Berachain mainnet without --cache specified, bump default cache allowance

--- a/cmd/bera-geth/main.go
+++ b/cmd/bera-geth/main.go
@@ -313,7 +313,9 @@ func prepare(ctx *cli.Context) {
 		log.Info("Starting bera-geth on Berachain mainnet...")
 
 	default:
-		if !ctx.IsSet(utils.DeveloperFlag.Name) {
+		if !ctx.IsSet(utils.DeveloperFlag.Name) &&
+			!ctx.IsSet(utils.OverrideGenesisFlag.Name) &&
+			!ctx.IsSet(utils.NetworkIdFlag.Name) {
 			log.Info("Starting bera-geth on Berachain mainnet...")
 		}
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1029,12 +1029,13 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 var (
 	// TestnetFlags is the flag group of all built-in supported testnets.
 	TestnetFlags = []cli.Flag{
+		BepoliaFlag,
 		SepoliaFlag,
 		HoleskyFlag,
 		HoodiFlag,
 	}
 	// NetworkFlags is the flag group of all built-in supported networks.
-	NetworkFlags = append([]cli.Flag{MainnetFlag}, TestnetFlags...)
+	NetworkFlags = append([]cli.Flag{BerachainFlag, MainnetFlag}, TestnetFlags...)
 
 	// DatabaseFlags is the flag group of all database flags.
 	DatabaseFlags = []cli.Flag{
@@ -1067,6 +1068,9 @@ func MakeDataDir(ctx *cli.Context) string {
 		}
 		if ctx.Bool(HoodiFlag.Name) {
 			return filepath.Join(path, "hoodi")
+		}
+		if ctx.Bool(BepoliaFlag.Name) {
+			return filepath.Join(path, "bepolia")
 		}
 		return path
 	}
@@ -1132,6 +1136,8 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 			urls = params.SepoliaBootnodes
 		case ctx.Bool(HoodiFlag.Name):
 			urls = params.HoodiBootnodes
+		case ctx.Bool(BerachainFlag.Name):
+			urls = params.BerachainBootnodes
 		case ctx.Bool(BepoliaFlag.Name):
 			urls = params.BepoliaBootnodes
 		}
@@ -1493,6 +1499,8 @@ func SetDataDir(ctx *cli.Context, cfg *node.Config) {
 		cfg.DataDir = filepath.Join(node.DefaultDataDir(), "holesky")
 	case ctx.Bool(HoodiFlag.Name) && cfg.DataDir == node.DefaultDataDir():
 		cfg.DataDir = filepath.Join(node.DefaultDataDir(), "hoodi")
+	case ctx.Bool(BepoliaFlag.Name) && cfg.DataDir == node.DefaultDataDir():
+		cfg.DataDir = filepath.Join(node.DefaultDataDir(), "bepolia")
 	}
 }
 
@@ -1823,6 +1831,14 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.NetworkId = 560048
 		cfg.Genesis = core.DefaultHoodiGenesisBlock()
 		SetDNSDiscoveryDefaults(cfg, params.HoodiGenesisHash)
+	case ctx.Bool(BepoliaFlag.Name):
+		cfg.NetworkId = 80069
+		cfg.Genesis = core.DefaultBepoliaGenesisBlock()
+		SetDNSDiscoveryDefaults(cfg, params.BepoliaGenesisHash)
+	case ctx.Bool(BerachainFlag.Name):
+		cfg.NetworkId = 80094
+		cfg.Genesis = core.DefaultBerachainGenesisBlock()
+		SetDNSDiscoveryDefaults(cfg, params.BerachainGenesisHash)
 	case ctx.Bool(DeveloperFlag.Name):
 		cfg.NetworkId = 1337
 		cfg.SyncMode = ethconfig.FullSync
@@ -1918,9 +1934,10 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		}
 		cfg.Genesis = genesis
 	default:
-		if cfg.NetworkId == 1 {
-			SetDNSDiscoveryDefaults(cfg, params.MainnetGenesisHash)
+		if cfg.Genesis == nil {
+			cfg.Genesis = core.DefaultBerachainGenesisBlock()
 		}
+		SetDNSDiscoveryDefaults(cfg, params.BerachainGenesisHash)
 	}
 	// Set any dangling config values
 	if ctx.String(CryptoKZGFlag.Name) != "gokzg" && ctx.String(CryptoKZGFlag.Name) != "ckzg" {
@@ -2249,20 +2266,25 @@ func DialRPCWithHeaders(endpoint string, headers []string) (*rpc.Client, error) 
 }
 
 func MakeGenesis(ctx *cli.Context) *core.Genesis {
-	var genesis *core.Genesis
 	switch {
 	case ctx.Bool(MainnetFlag.Name):
-		genesis = core.DefaultGenesisBlock()
+		return core.DefaultGenesisBlock()
 	case ctx.Bool(HoleskyFlag.Name):
-		genesis = core.DefaultHoleskyGenesisBlock()
+		return core.DefaultHoleskyGenesisBlock()
 	case ctx.Bool(SepoliaFlag.Name):
-		genesis = core.DefaultSepoliaGenesisBlock()
+		return core.DefaultSepoliaGenesisBlock()
 	case ctx.Bool(HoodiFlag.Name):
-		genesis = core.DefaultHoodiGenesisBlock()
+		return core.DefaultHoodiGenesisBlock()
+	case ctx.Bool(BepoliaFlag.Name):
+		return core.DefaultBepoliaGenesisBlock()
+	case ctx.Bool(BerachainFlag.Name):
+		return core.DefaultBerachainGenesisBlock()
 	case ctx.Bool(DeveloperFlag.Name):
 		Fatalf("Developer chains are ephemeral")
+		return nil
+	default:
+		return core.DefaultBerachainGenesisBlock()
 	}
-	return genesis
 }
 
 // MakeChain creates a chain manager from set command line flags.

--- a/cmd/utils/network_test.go
+++ b/cmd/utils/network_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"flag"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/urfave/cli/v2"
+)
+
+func testCLIContext(t *testing.T, flags []cli.Flag, args ...string) *cli.Context {
+	t.Helper()
+
+	app := cli.NewApp()
+	app.Flags = flags
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	for _, f := range flags {
+		if err := f.Apply(set); err != nil {
+			t.Fatalf("failed to apply flag: %v", err)
+		}
+	}
+	if err := set.Parse(args); err != nil {
+		t.Fatalf("failed to parse args: %v", err)
+	}
+	return cli.NewContext(app, set, nil)
+}
+
+var setEthConfigTestFlags = []cli.Flag{
+	BerachainFlag,
+	BepoliaFlag,
+	MainnetFlag,
+	SepoliaFlag,
+	HoleskyFlag,
+	HoodiFlag,
+	DeveloperFlag,
+	OverrideGenesisFlag,
+	NetworkIdFlag,
+	GCModeFlag,
+	CacheFlag,
+	CacheDatabaseFlag,
+	CacheTrieFlag,
+	CacheGCFlag,
+	CacheSnapshotFlag,
+	CachePreimagesFlag,
+	SnapshotFlag,
+	CryptoKZGFlag,
+	FDLimitFlag,
+	StateSizeTrackingFlag,
+	VMWitnessStatsFlag,
+}
+
+func TestMakeGenesisNetworkPresets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		args        []string
+		wantChainID uint64
+	}{
+		{name: "default", args: nil, wantChainID: 80094},
+		{name: "berachain", args: []string{"--berachain"}, wantChainID: 80094},
+		{name: "bepolia", args: []string{"--bepolia"}, wantChainID: 80069},
+		{name: "mainnet", args: []string{"--mainnet"}, wantChainID: 1},
+		{name: "sepolia", args: []string{"--sepolia"}, wantChainID: 11155111},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testCLIContext(t, NetworkFlags, tt.args...)
+			genesis := MakeGenesis(ctx)
+			if genesis == nil || genesis.Config == nil {
+				t.Fatal("expected non-nil genesis config")
+			}
+			if got := genesis.Config.ChainID.Uint64(); got != tt.wantChainID {
+				t.Fatalf("chain id mismatch: got %d, want %d", got, tt.wantChainID)
+			}
+		})
+	}
+}
+
+func TestSetEthConfigNetworkPresets(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantNet     uint64
+		wantChainID uint64
+	}{
+		{name: "default", args: nil, wantNet: 0, wantChainID: 80094},
+		{name: "berachain", args: []string{"--berachain"}, wantNet: 80094, wantChainID: 80094},
+		{name: "bepolia", args: []string{"--bepolia"}, wantNet: 80069, wantChainID: 80069},
+		{name: "mainnet", args: []string{"--mainnet"}, wantNet: 1, wantChainID: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stack, err := node.New(&node.DefaultConfig)
+			if err != nil {
+				t.Fatalf("failed to create node: %v", err)
+			}
+			defer stack.Close()
+
+			ctx := testCLIContext(t, setEthConfigTestFlags, tt.args...)
+			cfg := ethconfig.Defaults
+			SetEthConfig(ctx, stack, &cfg)
+			if cfg.NetworkId != tt.wantNet {
+				t.Fatalf("network id mismatch: got %d, want %d", cfg.NetworkId, tt.wantNet)
+			}
+			if cfg.Genesis == nil || cfg.Genesis.Config == nil {
+				t.Fatal("expected non-nil genesis config")
+			}
+			if got := cfg.Genesis.Config.ChainID.Uint64(); got != tt.wantChainID {
+				t.Fatalf("chain id mismatch: got %d, want %d", got, tt.wantChainID)
+			}
+		})
+	}
+}
+
+func TestSetDataDirBepolia(t *testing.T) {
+	t.Parallel()
+
+	ctx := testCLIContext(t, NetworkFlags, "--bepolia")
+	cfg := node.DefaultConfig
+	SetDataDir(ctx, &cfg)
+	want := filepath.Join(node.DefaultDataDir(), "bepolia")
+	if cfg.DataDir != want {
+		t.Fatalf("datadir mismatch: got %s, want %s", cfg.DataDir, want)
+	}
+}
+
+func TestIsNetworkPresetBerachainBepolia(t *testing.T) {
+	t.Parallel()
+
+	if IsNetworkPreset(testCLIContext(t, NetworkFlags)) {
+		t.Fatal("expected no preset without flags")
+	}
+	if !IsNetworkPreset(testCLIContext(t, NetworkFlags, "--berachain")) {
+		t.Fatal("expected berachain to be a network preset")
+	}
+	if !IsNetworkPreset(testCLIContext(t, NetworkFlags, "--bepolia")) {
+		t.Fatal("expected bepolia to be a network preset")
+	}
+}
+
+func TestDefaultsBerachainGenesis(t *testing.T) {
+	t.Parallel()
+
+	if ethconfig.Defaults.Genesis == nil || ethconfig.Defaults.Genesis.Config == nil {
+		t.Fatal("expected default genesis config")
+	}
+	if got := ethconfig.Defaults.Genesis.Config.ChainID.Uint64(); got != 80094 {
+		t.Fatalf("default genesis chain id mismatch: got %d, want 80094", got)
+	}
+}

--- a/cmd/utils/network_test.go
+++ b/cmd/utils/network_test.go
@@ -110,7 +110,9 @@ func TestSetEthConfigNetworkPresets(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stack, err := node.New(&node.DefaultConfig)
+			ncfg := node.DefaultConfig
+			ncfg.DataDir = "" // keep tests hermetic; avoid touching the host filesystem
+			stack, err := node.New(&ncfg)
 			if err != nil {
 				t.Fatalf("failed to create node: %v", err)
 			}

--- a/cmd/utils/network_test.go
+++ b/cmd/utils/network_test.go
@@ -163,10 +163,9 @@ func TestIsNetworkPresetBerachainBepolia(t *testing.T) {
 func TestDefaultsBerachainGenesis(t *testing.T) {
 	t.Parallel()
 
-	if ethconfig.Defaults.Genesis == nil || ethconfig.Defaults.Genesis.Config == nil {
-		t.Fatal("expected default genesis config")
-	}
-	if got := ethconfig.Defaults.Genesis.Config.ChainID.Uint64(); got != 80094 {
-		t.Fatalf("default genesis chain id mismatch: got %d, want 80094", got)
+	// Genesis is resolved lazily in SetEthConfig to avoid decoding the large
+	// Berachain prealloc at ethconfig package init time.
+	if ethconfig.Defaults.Genesis != nil {
+		t.Fatal("expected nil genesis in Defaults; use SetEthConfig to resolve")
 	}
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -293,7 +293,7 @@ func (o *ChainOverrides) apply(cfg *params.ChainConfig) error {
 //
 //	                     genesis == nil       genesis != nil
 //	                  +------------------------------------------
-//	db has no genesis |  main-net default  |  genesis
+//	db has no genesis |  berachain default |  genesis
 //	db has genesis    |  from DB           |  genesis (if compatible)
 //
 // The stored chain configuration will be updated if it is compatible (i.e. does not

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -47,11 +47,12 @@ var FullNodeGPO = gasprice.Config{
 	IgnorePrice:      gasprice.DefaultIgnorePrice,
 }
 
-// Defaults contains default settings for use on the Ethereum and Berachain main net.
+// Defaults contains default settings for use on the Berachain main net.
 var Defaults = Config{
 	HistoryMode:          history.KeepAll,
 	SyncMode:             SnapSync,
 	NetworkId:            0, // enable auto configuration of networkID == chainID
+	Genesis:              core.DefaultBerachainGenesisBlock(),
 	TxLookupLimit:        2350000,
 	TransactionHistory:   2350000,
 	LogHistory:           2350000,
@@ -79,7 +80,7 @@ var Defaults = Config{
 // Config contains configuration options for ETH and LES protocols.
 type Config struct {
 	// The genesis block, which is inserted if the database is empty.
-	// If nil, the Ethereum main net block is used.
+	// If nil, the Berachain main net block is used.
 	Genesis *core.Genesis `toml:",omitempty"`
 
 	// Network ID separates blockchains on the peer-to-peer networking level. When left

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -52,7 +52,6 @@ var Defaults = Config{
 	HistoryMode:          history.KeepAll,
 	SyncMode:             SnapSync,
 	NetworkId:            0, // enable auto configuration of networkID == chainID
-	Genesis:              core.DefaultBerachainGenesisBlock(),
 	TxLookupLimit:        2350000,
 	TransactionHistory:   2350000,
 	LogHistory:           2350000,


### PR DESCRIPTION
Closes #104

## Summary

- Default `bera-geth` to Berachain mainnet in `SetEthConfig`, `ethconfig.Defaults`, and `MakeGenesis`
- Register and wire `--berachain` and `--bepolia` CLI flags
- Add Bepolia datadir subfolder and fix `dumpgenesis` fallback on empty/missing chaindata


## Test plan

- [x] `go test ./cmd/utils/ ./core/` (network preset + genesis tests)
- [x] `dumpgenesis` → 80094 (default), 80069 (`--bepolia`), 1 (`--mainnet`)